### PR TITLE
Fix styles and colors when running with a dark Bootstrap theme

### DIFF
--- a/src/Launchpad/wwwroot/Launchpad/elements/launchpad-panel/launchpad-panel.html
+++ b/src/Launchpad/wwwroot/Launchpad/elements/launchpad-panel/launchpad-panel.html
@@ -39,11 +39,12 @@
             .launchpad-tile > a,
             .launchpad-tile:hover a {
                 display: block;
-                color: black;
+                color: inherit;
                 text-decoration: none;
             }
 
-            .launchpad-tile h5 {
+            .launchpad-tile .launchpad-label {
+                display: block;
                 text-align: center;
                 margin: 2px;
                 height: 14px;
@@ -61,7 +62,7 @@
                         <div class="launchpad-icon">
                             <template is="imported-template" content$="{{item.html}}"></template>
                         </div>
-                        <h5 title="{{item.description}}">{{item.name}}</h5>
+                        <span class="launchpad-label" title="{{item.description}}">{{item.name}}</span>
                     </a>
                 </div>
             </template>


### PR DESCRIPTION
Fixes: #5 

Note that it only fixes the link color. The icon color is something else, because the icon is an SVG provided by the app.

@un-tone can you pls review?