### PR TITLE
Fix icon display

### DIFF
--- a/src/Launchpad/Api/MainHandlers.cs
+++ b/src/Launchpad/Api/MainHandlers.cs
@@ -34,10 +34,12 @@ namespace Launchpad.Api
 
                 return new LaunchpadPage
                 {
-                    Applications = Self.GET<Json>("/launchpad/applications", () => new Json()),
+                    Applications = Self.GET<Json>("/launchpad/applications"),
                     Layout = layout
                 };
             }, new HandlerOptions { SelfOnly = true });
+
+            Handle.GET("/launchpad/applications", () => new Json());
 
             Handle.GET("/launchpad/settings", () =>
             {


### PR DESCRIPTION
problem: Launchpad does not display icons from other apps

explanation: there is a regression in Starcounter 2.3.1.7371 which makes blending rules not trigger if Self.GET uses an unexisting URI with a substitute handler

solution: replace the substitute handler with a concrete handler

@alemoi is this regression intentional? For sure it was working few weeks ago.