### PR TITLE
Change because `content` attribute is deprecated.

### DIFF
--- a/src/Launchpad/wwwroot/Launchpad/elements/launchpad-panel/launchpad-panel.html
+++ b/src/Launchpad/wwwroot/Launchpad/elements/launchpad-panel/launchpad-panel.html
@@ -83,7 +83,7 @@
                 <div class="launchpad-grid__tile">
                     <a href="{{item.url}}">
                         <div class="launchpad-grid__tile-icon">
-                            <template is="imported-template" content$="{{item.html}}"></template>
+                            <template is="imported-template" href$="{{item.html}}"></template>
                         </div>
                         <span class="launchpad-grid__tile-label" title="{{item.description}}">{{item.name}}</span>
                     </a>


### PR DESCRIPTION
I don't know the relevant issue, but you can notice the warning in the console.

![launchpad](https://user-images.githubusercontent.com/8951553/31636995-0960ecfe-b2cd-11e7-8c2e-50e115a6b1a6.gif)
